### PR TITLE
Support for CSS shorthands

### DIFF
--- a/Dynamic Button.sketchplugin
+++ b/Dynamic Button.sketchplugin
@@ -75,14 +75,13 @@ if(!is_group(layer)){
 		newGroup.name = "flex button";
 		var newRect = [newGroup addLayerOfType:'rectangle']
 		newRect.name = "BG";
+		[[newRect frame] setHeight:(layerHeight + offsetTop + offsetBottom)];
+		[[newRect frame] setWidth:(layerWidth + offsetLeft + offsetRight)];
+		[[newRect frame] setX: layerX - offsetLeft];
+		[[newRect frame] setY: layerY - offsetTop];
 
 		var style = [[newRect style] fills];
 		style.addNewStylePart();
-
-	[[newRect frame] setHeight:layerHeight]; 
-	[[newRect frame] setWidth:layerWidth];
-	[[newRect frame] setX: layerX];
-	[[newRect frame] setY: layerY];
 
 		newLayer = [layer duplicate];
 		[parentGroup removeLayer:newLayer];


### PR DESCRIPTION
Added shorthand naming like CSS paddings: 20:10 or just a simple 10 will now also work.
Plus some other small fixes:
- immediately setting the background size is the padding name is already there,
- only work when the layer is not a group
- all whitespace to tabs
